### PR TITLE
Prometheus remote-write poc configuration

### DIFF
--- a/manifests/monitoring/prometheus.yaml
+++ b/manifests/monitoring/prometheus.yaml
@@ -54,8 +54,13 @@ metadata:
 data:
   prometheus.yaml: |
     global:
-      scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-      evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+      scrape_interval: 15s
+      evaluation_interval: 15s
+    remote_write:
+      - url: https://prometheus-prod-10-prod-us-central-0.grafana.net/api/prom/push
+        basic_auth:
+          username: $PROM_REMOTE_WRITE_USER
+          password: $PROM_REMOTE_WRITE_PASSWORD
     scrape_configs:
       - job_name: 'node0'
         static_configs:


### PR DESCRIPTION
- Configure charon prometheus to work in agent-mode and ingest metrics to central a prom backend.